### PR TITLE
Mark symbols public instead of exporting.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUToolbox"
 uuid = "096a3bc2-3ced-46d0-87f4-dd12716f4bfc"
-version = "0.1.0"
+version = "0.2.0"
 
 [compat]
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Functionality
 
-This package currently exports the following:
+This package currently has the following public symbols:
 - `SimpleVersion`: a GPU-compatible version number
 - `@sv_str`: constructs a SimpleVersion from a string
 - `@checked`: Add to a function definition to generate an unchecked and a checked version.

--- a/src/ccalls.jl
+++ b/src/ccalls.jl
@@ -1,7 +1,8 @@
 # utilities for calling foreign functionality more conveniently
 
-export @checked, @debug_ccall, @gcsafe_ccall
-
+if VERSION >= v"1.11.0-DEV.469"
+    eval(Meta.parse("public @checked, @debug_ccall, @gcsafe_ccall"))
+end
 
 ## function wrapper for checking the return value of a function
 

--- a/src/simpleversion.jl
+++ b/src/simpleversion.jl
@@ -1,4 +1,6 @@
-export SimpleVersion, @sv_str
+if VERSION >= v"1.11.0-DEV.469"
+    eval(Meta.parse("public SimpleVersion, @sv_str"))
+end
 
 """
     SimpleVersion(major, [minor])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test
-using GPUToolbox
+using GPUToolbox: SimpleVersion, @sv_str
 
 @testset "GPUToolbox.jl" begin
     @testset "SimpleVersion" begin


### PR DESCRIPTION
Given the nature of this package, I think we should encourage explicit import of functionality in the packages that depend on GPUToolbox.

I originally didn't implement this, as Compat.jl adds a bunch of standard library dependencies to this no-dependency package, but then I found https://discourse.julialang.org/t/is-compat-jl-worth-it-for-the-public-keyword/119041/11.

It's not pretty, but it works.

Technically breaking, but all backends already explicity import the GPUToolbox functionality that they use, so it'll just be a matter of me opening PRs to add "0.2" to the compat for each of the packages.