### PR TITLE
Fixup `Literal` docstring

### DIFF
--- a/src/literals.jl
+++ b/src/literals.jl
@@ -14,7 +14,6 @@ One can use the object in suffix form `1*i8` or `1i8` to perform the conversion.
 - `u8`: Convert to `UInt8`
 - `u16`: Convert to `UInt16`
 - `u32`: Convert to `UInt32`
-```
 """
 struct Literal{T} end
 Base.:(*)(x::Number, ::Type{Literal{T}}) where {T} = T(x)


### PR DESCRIPTION
Should the docstring also say `GPUToolbox.Literal` since the symbol isn't exported?
https://juliagpu.github.io/GPUToolbox.jl/dev/#GPUToolbox.Literal