### PR TITLE
Fix macOS x64 runners

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['lts', '1.11', 'nightly']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-13, windows-latest]
         arch: [x64]
         include:
           - version: 'lts'


### PR DESCRIPTION
Only `macOS-13` provides intel architecture macOS. ([source](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories))
