### PR TITLE
Use `Republic.@public` in `@enum_without_prefix`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,9 @@ version = "1.1.1"
 
 [deps]
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
+Republic = "27243419-9dde-4721-b67c-fd63626fea7f"
 
 [compat]
 LLVM = "4, 5, 6, 7, 8, 9"
+Republic = "2"
 julia = "1.10"

--- a/src/enum.jl
+++ b/src/enum.jl
@@ -1,5 +1,6 @@
 export @enum_without_prefix
 
+using Republic: @public
 
 ## redeclare enum values without a prefix
 
@@ -50,9 +51,7 @@ macro enum_without_prefix(ex...)
         if visibility == :export
             push!(ex.args, :(export $short))
         elseif visibility == :public
-            if VERSION >= v"1.11.0-DEV.469"
-                push!(ex.args, Expr(:public, short))
-            end
+            push!(ex.args, :($(@__MODULE__).@public $short))
         end
     end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 IOCapture = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Republic = "27243419-9dde-4721-b67c-fd63626fea7f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using GPUToolbox
 using InteractiveUtils
 using IOCapture
+using Republic: public_names
 
 @testset "GPUToolbox.jl" begin
     @testset "SimpleVersion" begin
@@ -100,18 +101,16 @@ using IOCapture
         @test :B in exported
 
         # test with visibility=:public
-        @static if VERSION >= v"1.11"
-            mod_public = @eval module $(gensym())
-                using GPUToolbox
-                @enum MY_ENUM MY_ENUM_P MY_ENUM_Q
-                @enum_without_prefix visibility=:public MY_ENUM MY_ENUM_
-            end
-            @test mod_public.P == mod_public.MY_ENUM_P
-            @test mod_public.Q == mod_public.MY_ENUM_Q
-            # public but not exported
-            @test :P in names(mod_public)
-            @test !Base.isexported(mod_public, :P)
+        mod_public = @eval module $(gensym())
+            using GPUToolbox
+            @enum MY_ENUM MY_ENUM_P MY_ENUM_Q
+            @enum_without_prefix visibility=:public MY_ENUM MY_ENUM_
         end
+        @test mod_public.P == mod_public.MY_ENUM_P
+        @test mod_public.Q == mod_public.MY_ENUM_Q
+        # public but not exported
+        @test :P in public_names(mod_public)
+        @test !Base.isexported(mod_public, :P)
     end
 
     @testset "LazyInitialized" begin


### PR DESCRIPTION
Use `Republic.@public` for visibility argument in `@enum_without_prefix`

For context, see https://github.com/JuliaGPU/CUDA.jl/pull/3103.