### PR TITLE
Redesign @memoize and LazyInitialized for session and thread safety

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -18,14 +18,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['lts', '1.11', 'nightly']
-        os: [ubuntu-latest, macOS-13, windows-latest]
+        version: ['lts', '1', 'nightly']
+        os: [ubuntu-latest, windows-latest]
         arch: [x64]
         include:
           - version: 'lts'
             os: 'macOS-latest'
             arch: 'aarch64'
-          - version: '1.11'
+          - version: '1'
             os: 'macOS-latest'
             arch: 'aarch64'
           - version: 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUToolbox"
 uuid = "096a3bc2-3ced-46d0-87f4-dd12716f4bfc"
-version = "1.1.1"
+version = "2.0.0"
 
 [deps]
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"

--- a/src/memoization.jl
+++ b/src/memoization.jl
@@ -1,18 +1,134 @@
 export @memoize
 
+@static if VERSION >= v"1.11"
+    const _SlotArray{T} = AtomicMemory{Union{Nothing,T}}
+else
+    const _SlotArray{T} = Vector{Union{Nothing,T}}
+end
+
+mutable struct FixedMemo{T}
+    @atomic data::Union{Nothing,_SlotArray{T}}
+    const lock::ReentrantLock
+end
+FixedMemo{T}() where {T} = FixedMemo{T}(nothing, ReentrantLock())
+
+mutable struct DictMemo{K,V}
+    dict::Dict{K,V}
+    const lock::ReentrantLock
+end
+DictMemo{K,V}() where {K,V} = DictMemo{K,V}(Dict{K,V}(), ReentrantLock())
+
+@inline memoize_should_publish() = !generating_output() || HAS_FIELD_REPLACE
+
+Base.@propagate_inbounds @inline function memoize_slot_load(data::_SlotArray{T}, key) where {T}
+    @boundscheck checkbounds(data, key)
+    @static if VERSION >= v"1.12"
+        return @inbounds @atomic :acquire data[key]
+    elseif VERSION >= v"1.11"
+        # the `@atomic` macro only gained `AtomicMemory` element access on 1.12;
+        # use the `Core.memoryref*` intrinsics as the bridge on 1.11.
+        ref = Core.memoryrefnew(Core.memoryref(data), Int(key), false)
+        return Core.memoryrefget(ref, :acquire, false)
+    else
+        return @inbounds data[key]
+    end
+end
+
+Base.@propagate_inbounds @inline function memoize_slot_store!(
+    data::_SlotArray{T}, key, val::Union{Nothing,T}
+) where {T}
+    @boundscheck checkbounds(data, key)
+    @static if VERSION >= v"1.12"
+        @inbounds @atomic :release data[key] = val
+    elseif VERSION >= v"1.11"
+        ref = Core.memoryrefnew(Core.memoryref(data), Int(key), false)
+        Core.memoryrefset!(ref, val, :release, false)
+    else
+        @inbounds data[key] = val
+    end
+    return val
+end
+
+function memoize_new_slots(::Type{T}, len) where {T}
+    data = _SlotArray{T}(undef, len)
+    for i in eachindex(data)
+        memoize_slot_store!(data, i, nothing)
+    end
+    return data
+end
+
+@noinline function memoize_fixed_data!(m::FixedMemo{T}, len) where {T}
+    data = @atomic :acquire m.data
+    data !== nothing && return data
+    memoize_should_publish() || return nothing
+
+    @lock m.lock begin
+        data = @atomic :acquire m.data
+        if data === nothing
+            data = memoize_new_slots(T, len)
+            generating_output() && wipe_on_serialize!(m, :data, nothing)
+            @atomic :release m.data = data
+        end
+        return data
+    end
+end
+
+@noinline function memoize_slow!(constructor, m::FixedMemo{T}, key, len) where {T}
+    @static if VERSION >= v"1.11"
+        data = memoize_fixed_data!(m, len)
+        if data === nothing
+            checkbounds(1:len, key)
+            return constructor()::T
+        end
+
+        cached = memoize_slot_load(data, key)
+        cached !== nothing && return cached::T
+
+        val = constructor()::T
+        if memoize_should_publish()
+            generating_output() && wipe_on_serialize!(m, :data, nothing)
+            memoize_slot_store!(data, key, val)
+        end
+        return val
+    else
+        @lock m.lock begin
+            data = @atomic :acquire m.data
+            if data === nothing
+                if !memoize_should_publish()
+                    checkbounds(1:len, key)
+                    return constructor()::T
+                end
+                data = memoize_new_slots(T, len)
+                generating_output() && wipe_on_serialize!(m, :data, nothing)
+                @atomic :release m.data = data
+            end
+
+            cached = memoize_slot_load(data, key)
+            cached !== nothing && return cached::T
+
+            val = constructor()::T
+            if memoize_should_publish()
+                generating_output() && wipe_on_serialize!(m, :data, nothing)
+                memoize_slot_store!(data, key, val)
+            end
+            return val
+        end
+    end
+end
+
 """
     @memoize [key::T] [maxlen=...] begin
         # expensive computation
     end::T
 
-Low-level, no-frills memoization macro that stores values in a thread-local, typed cache.
+Low-level, no-frills memoization macro that stores values in a process-local, typed cache.
 The types of the caches are derived from the syntactical type assertions.
 
-The cache consists of two levels, the outer one indexed with the thread index. If no `key`
-is specified, the second level of the cache is dropped.
-
-If the the `maxlen` option is specified, the `key` is assumed to be an  integer, and the
-secondary cache will be a vector with length `maxlen`. Otherwise, a dictionary is used.
+If the `maxlen` option is specified, the `key` is assumed to be an integer, and the
+cache will be a fixed-size array with length `maxlen`. Otherwise, a dictionary is used.
+On Julia 1.11+, fixed-size slots use atomic per-element access. Atomic slot access is
+lock-free for pointer-representable values; other values may use Julia's internal
+per-element atomic fallback.
 """
 macro memoize(ex...)
     code = ex[end]
@@ -36,81 +152,127 @@ macro memoize(ex...)
         options[arg.args[1]] = arg.args[2]
     end
 
-    # the global cache is an array with one entry per thread. if we don't have to key on
-    # anything, that entry will be the memoized new_value, or else a dictionary of values.
     @gensym global_cache
+    mod = @__MODULE__
+    lazy_ty = GlobalRef(mod, :LazyInitialized)
+    fixed_ty = GlobalRef(mod, :FixedMemo)
+    dict_ty = GlobalRef(mod, :DictMemo)
+    slot_load = GlobalRef(mod, :memoize_slot_load)
+    slot_store = GlobalRef(mod, :memoize_slot_store!)
+    new_slots = GlobalRef(mod, :memoize_new_slots)
+    fixed_slow = GlobalRef(mod, :memoize_slow!)
+    should_publish = GlobalRef(mod, :memoize_should_publish)
+    generating = GlobalRef(mod, :generating_output)
+    wipe = GlobalRef(mod, :wipe_on_serialize!)
 
-    # in the presence of thread adoption, we need to use the maximum thread ID
-    nthreads = :( Threads.maxthreadid() )
+    rettyp_esc = esc(rettyp)
+    code_esc = esc(code)
 
-    # generate code to access memoized values
-    # (assuming the global_cache can be indexed with the thread ID)
     if key === nothing
-        # if we don't have to key on anything, use the global cache directly
-        global_cache_eltyp = :(Union{Nothing,$rettyp})
+        @eval __module__ begin
+            const $global_cache = $lazy_ty{$rettyp}()
+        end
+
         ex = quote
-            cache = get!($(esc(global_cache))) do
-                $global_cache_eltyp[nothing for _ in 1:$nthreads]
-            end
-            cached_value = @inbounds cache[Threads.threadid()]
-            if cached_value !== nothing
-                cached_value
-            else
-                new_value = $(esc(code))::$rettyp
-                @inbounds cache[Threads.threadid()] = new_value
-                new_value
+            let cache = $(esc(global_cache))
+                val = @atomic :acquire cache.value
+                if val !== nothing
+                    val::$rettyp_esc
+                else
+                    Base.get!(cache) do
+                        $code_esc::$rettyp_esc
+                    end
+                end
             end
         end
     elseif haskey(options, :maxlen)
-        # if we know the length of the cache, use a fixed-size array
-        global_cache_eltyp = :(Vector{Union{Nothing,$rettyp}})
-        global_init = :(Union{Nothing,$rettyp}[nothing for _ in 1:$(esc(options[:maxlen]))])
+        @eval __module__ begin
+            const $global_cache = $fixed_ty{$rettyp}()
+        end
+
+        key_val_esc = esc(key.val)
+        maxlen_esc = esc(options[:maxlen])
         ex = quote
-            cache = get!($(esc(global_cache))) do
-                $global_cache_eltyp[$global_init for _ in 1:$nthreads]
-            end
-            local_cache = @inbounds begin
-                tid = Threads.threadid()
-                assume(isassigned(cache, tid))
-                cache[tid]
-            end
-            cached_value = @inbounds local_cache[$(esc(key.val))]
-            if cached_value !== nothing
-                cached_value
-            else
-                new_value = $(esc(code))::$rettyp
-                @inbounds local_cache[$(esc(key.val))] = new_value
-                new_value
+            let cache = $(esc(global_cache)), key = $key_val_esc
+                @static if VERSION >= v"1.11"
+                    data = @atomic :acquire cache.data
+                    if data !== nothing
+                        cached_value = $slot_load(data, key)
+                        if cached_value !== nothing
+                            cached_value::$rettyp_esc
+                        else
+                            $fixed_slow(cache, key, $maxlen_esc) do
+                                $code_esc::$rettyp_esc
+                            end
+                        end
+                    else
+                        $fixed_slow(cache, key, $maxlen_esc) do
+                            $code_esc::$rettyp_esc
+                        end
+                    end
+                else
+                    @lock cache.lock begin
+                        len = $maxlen_esc
+                        publish = $should_publish()
+                        data = @atomic :acquire cache.data
+                        if data === nothing
+                            if !publish
+                                checkbounds(1:len, key)
+                                $code_esc::$rettyp_esc
+                            else
+                                data = $new_slots($rettyp_esc, len)
+                                $generating() && $wipe(cache, :data, nothing)
+                                @atomic :release cache.data = data
+
+                                cached_value = $slot_load(data, key)
+                                if cached_value !== nothing
+                                    cached_value::$rettyp_esc
+                                else
+                                    new_value = $code_esc::$rettyp_esc
+                                    $generating() && $wipe(cache, :data, nothing)
+                                    $slot_store(data, key, new_value)
+                                    new_value
+                                end
+                            end
+                        else
+                            cached_value = $slot_load(data, key)
+                            if cached_value !== nothing
+                                cached_value::$rettyp_esc
+                            else
+                                new_value = $code_esc::$rettyp_esc
+                                if publish
+                                    $generating() && $wipe(cache, :data, nothing)
+                                    $slot_store(data, key, new_value)
+                                end
+                                new_value
+                            end
+                        end
+                    end
+                end
             end
         end
     else
-        # otherwise, fall back to a dictionary
-        global_cache_eltyp = :(Dict{$(key.typ),$rettyp})
-        global_init = :(Dict{$(key.typ),$rettyp}())
-        ex = quote
-            cache = get!($(esc(global_cache))) do
-                $global_cache_eltyp[$global_init for _ in 1:$nthreads]
-            end
-            local_cache = @inbounds begin
-                tid = Threads.threadid()
-                assume(isassigned(cache, tid))
-                cache[tid]
-            end
-            cached_value = get(local_cache, $(esc(key.val)), nothing)
-            if cached_value !== nothing
-                cached_value
-            else
-                new_value = $(esc(code))::$rettyp
-                local_cache[$(esc(key.val))] = new_value
-                new_value
-            end
+        @eval __module__ begin
+            const $global_cache = $dict_ty{$(key.typ),$rettyp}()
         end
-    end
 
-    # define the per-thread cache
-    @eval __module__ begin
-        const $global_cache = LazyInitialized{Vector{$(global_cache_eltyp)}}() do cache
-            length(cache) == $nthreads
+        key_val_esc = esc(key.val)
+        ex = quote
+            let cache = $(esc(global_cache)), key = $key_val_esc
+                @lock cache.lock begin
+                    dict = cache.dict
+                    if haskey(dict, key)
+                        dict[key]::$rettyp_esc
+                    else
+                        new_value = $code_esc::$rettyp_esc
+                        if $should_publish()
+                            $generating() && $wipe(cache, :dict, empty(dict))
+                            dict[key] = new_value
+                        end
+                        new_value
+                    end
+                end
+            end
         end
     end
 

--- a/src/memoization.jl
+++ b/src/memoization.jl
@@ -50,6 +50,7 @@ Base.@propagate_inbounds @inline function memoize_slot_store!(
 end
 
 function memoize_new_slots(::Type{T}, len) where {T}
+    len = Int(len)
     data = _SlotArray{T}(undef, len)
     for i in eachindex(data)
         memoize_slot_store!(data, i, nothing)
@@ -74,6 +75,7 @@ end
 end
 
 @noinline function memoize_slow!(constructor, m::FixedMemo{T}, key, len) where {T}
+    len = Int(len)
     @static if VERSION >= v"1.11"
         data = memoize_fixed_data!(m, len)
         if data === nothing

--- a/src/threading.jl
+++ b/src/threading.jl
@@ -1,5 +1,16 @@
 export LazyInitialized
 
+@inline generating_output() = ccall(:jl_generating_output, Cint, ()) != 0
+
+const HAS_FIELD_REPLACE = isdefined(Base, :OncePerProcess)
+
+@inline function wipe_on_serialize!(@nospecialize(obj), field::Symbol, @nospecialize(val))
+    @static if HAS_FIELD_REPLACE
+        ccall(:jl_set_precompile_field_replace, Cvoid, (Any, Any, Any), obj, field, val)
+    end
+    return
+end
+
 """
     LazyInitialized{T}()
 
@@ -9,55 +20,33 @@ value by calling `get!`. The constructor is ensured to only be called once.
 This type is intended for lazy initialization of e.g. global structures, without using
 `__init__`. It is similar to protecting accesses using a lock, but is much cheaper.
 
+The initialized value must not be `nothing`.
+
 """
-struct LazyInitialized{T,F}
-    # 0: uninitialized
-    # 1: initializing
-    # 2: initialized
-    guard::Threads.Atomic{Int}
-    value::Base.RefValue{T}
-    # XXX: use Base.ThreadSynchronizer instead?
-
-    validator::F
+mutable struct LazyInitialized{T}
+    @atomic value::Union{Nothing,T}
+    const lock::ReentrantLock
 end
 
-LazyInitialized{T}(validator=nothing) where {T} =
-    LazyInitialized{T,typeof(validator)}(Threads.Atomic{Int}(0), Ref{T}(), validator)
+LazyInitialized{T}() where {T} = LazyInitialized{T}(nothing, ReentrantLock())
 
-@inline function Base.get!(constructor::Base.Callable, x::LazyInitialized)
-    while x.guard[] != 2
-        initialize!(x, constructor)
-    end
-    assume(isassigned(x.value)) # to get rid of the check
-    val = x.value[]
-
-    # check if the value is still valid
-    if x.validator !== nothing && !x.validator(val)
-        Threads.atomic_cas!(x.guard, 2, 0)
-        while x.guard[] != 2
-            initialize!(x, constructor)
-        end
-        assume(isassigned(x.value))
-        val = x.value[]
-    end
-
-    return val
+@inline function Base.get!(constructor::Base.Callable, x::LazyInitialized{T}) where {T}
+    val = @atomic :acquire x.value
+    val !== nothing && return val::T
+    return slow_init!(constructor, x)::T
 end
 
-@noinline function initialize!(x::LazyInitialized{T}, constructor::F) where {T, F}
-    status = Threads.atomic_cas!(x.guard, 0, 1)
-    if status == 0
-        try
-          x.value[] = constructor()::T
-          x.guard[] = 2
-        catch
-          x.guard[] = 0
-          rethrow()
-        end
-    else
-        ccall(:jl_cpu_suspend, Cvoid, ())
-        # Temporary solution before we have gc transition support in codegen.
-        ccall(:jl_gc_safepoint, Cvoid, ())
+@noinline function slow_init!(constructor, x::LazyInitialized{T}) where {T}
+    if generating_output() && !HAS_FIELD_REPLACE
+        return constructor()::T
     end
-    return
+
+    @lock x.lock begin
+        val = @atomic :acquire x.value
+        val !== nothing && return val::T
+        val = constructor()::T
+        generating_output() && wipe_on_serialize!(x, :value, nothing)
+        @atomic :release x.value = val
+        return val
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -126,21 +126,22 @@ using IOCapture
             error("Should not be called")
         end == 42
 
-        # Test with validator
-        valid = Ref(true)
-        lazy_with_validator = LazyInitialized{Int}() do val
-            valid[]
+    end
+
+    @testset "LazyInitialized concurrency" begin
+        init_count = Threads.Atomic{Int}(0)
+        lazy = LazyInitialized{NTuple{4,Int}}()
+
+        function build_tuple()
+            id = Threads.atomic_add!(init_count, 1) + 1
+            yield()
+            return ntuple(Returns(id), 4)
         end
-        @test get!(lazy_with_validator) do
-            1
-        end == 1
-        @test get!(lazy_with_validator) do
-            2
-        end == 1
-        valid[] = false
-        @test get!(lazy_with_validator) do
-            3
-        end == 3
+
+        tasks = [Threads.@spawn get!(build_tuple, lazy) for _ in 1:128]
+        results = fetch.(tasks)
+        @test init_count[] == 1
+        @test all(==((1, 1, 1, 1)), results)
     end
 
     @testset "@memoize" begin
@@ -189,6 +190,135 @@ using IOCapture
         @test vec_call_count[] == 1  # Should not increment
         @test test_vec_memo(2) == 6
         @test vec_call_count[] == 2  # Should increment for new index
+    end
+
+    @testset "@memoize concurrency" begin
+        no_key_count = Threads.Atomic{Int}(0)
+        function memo_no_key_stress()
+            @memoize begin
+                Threads.atomic_add!(no_key_count, 1)
+                yield()
+                1234
+            end::Int
+        end
+
+        tasks = [Threads.@spawn memo_no_key_stress() for _ in 1:128]
+        @test all(==(1234), fetch.(tasks))
+        @test no_key_count[] == 1
+
+        dict_count = Threads.Atomic{Int}(0)
+        function memo_dict_stress(x)
+            @memoize x::Int begin
+                Threads.atomic_add!(dict_count, 1)
+                yield()
+                x * 10
+            end::Int
+        end
+
+        keys = [mod1(i, 16) for i in 1:256]
+        tasks = [Threads.@spawn memo_dict_stress(key) for key in keys]
+        @test fetch.(tasks) == keys .* 10
+        @test dict_count[] == 16
+
+        fixed_count = Threads.Atomic{Int}(0)
+        function memo_fixed_stress(x)
+            @memoize x::Int maxlen=16 begin
+                Threads.atomic_add!(fixed_count, 1)
+                yield()
+                x * 20
+            end::Int
+        end
+
+        tasks = [Threads.@spawn memo_fixed_stress(key) for key in keys]
+        @test fetch.(tasks) == keys .* 20
+        @test 16 <= fixed_count[] <= length(keys)
+
+        fixed_count_after_warmup = fixed_count[]
+        tasks = [Threads.@spawn memo_fixed_stress(key) for key in keys]
+        @test fetch.(tasks) == keys .* 20
+        @test fixed_count[] == fixed_count_after_warmup
+    end
+
+    @testset "Session-safe caches" begin
+        mktempdir() do dir
+            probe_dir = joinpath(dir, "MemoSessionProbe")
+            src_dir = joinpath(probe_dir, "src")
+            mkpath(src_dir)
+
+            write(joinpath(probe_dir, "Project.toml"), """
+            name = "MemoSessionProbe"
+            uuid = "5c47f73b-ac9c-4df8-9db3-37f1345bcb51"
+            version = "0.1.0"
+
+            [deps]
+            Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+            """)
+
+            write(joinpath(src_dir, "MemoSessionProbe.jl"), """
+            module MemoSessionProbe
+
+            using GPUToolbox
+
+            const PRECOMPILE = Ref((0, 0, 0, 0))
+            const LAZY = LazyInitialized{Int}()
+
+            lazy_pid() = get!(() -> Int(getpid()), LAZY)
+
+            function memo_no_key_pid()
+                @memoize begin
+                    Int(getpid())
+                end::Int
+            end
+
+            function memo_fixed_pid(key)
+                @memoize key::Int maxlen=2 begin
+                    Int(getpid())
+                end::Int
+            end
+
+            function memo_dict_pid(key)
+                @memoize key::Int begin
+                    Int(getpid())
+                end::Int
+            end
+
+            runtime_values() =
+                (lazy_pid(), memo_no_key_pid(), memo_fixed_pid(1), memo_dict_pid(1))
+
+            if ccall(:jl_generating_output, Cint, ()) != 0
+                PRECOMPILE[] = runtime_values()
+            end
+
+            end
+            """)
+
+            julia = joinpath(Sys.BINDIR, Base.julia_exename())
+            toolbox_path = pkgdir(GPUToolbox)
+            setup = """
+            using Pkg
+            Pkg.develop(PackageSpec(path=$(repr(toolbox_path))))
+            Pkg.instantiate()
+            using MemoSessionProbe
+            """
+            run(Cmd([julia, "--startup-file=no", "--project=$probe_dir", "-e", setup]))
+
+            check = """
+            using MemoSessionProbe
+            pre = MemoSessionProbe.PRECOMPILE[]
+            vals = MemoSessionProbe.runtime_values()
+            println("RESULT ", join((pre..., vals..., Int(getpid())), ","))
+            """
+            out = read(Cmd([julia, "--startup-file=no", "--project=$probe_dir", "-e", check]), String)
+            line = only(filter(startswith("RESULT "), split(out, '\n')))
+            nums = parse.(Int, split(chop(line; head=7, tail=0), ","))
+            precompile_vals = nums[1:4]
+            runtime_vals = nums[5:8]
+            runtime_pid = nums[9]
+
+            @test all(!=(0), precompile_vals)
+            @test all(==(runtime_pid), runtime_vals)
+            @test all(!=(runtime_pid), precompile_vals)
+        end
     end
 
     @testset "@checked" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,6 +190,20 @@ using IOCapture
         @test vec_call_count[] == 1  # Should not increment
         @test test_vec_memo(2) == 6
         @test vec_call_count[] == 2  # Should increment for new index
+
+        # `maxlen` may come from APIs that return smaller integer types.
+        int32_len_call_count = Ref(0)
+        function test_vec_memo_int32_len(x)
+            @memoize x::Int maxlen=Int32(10) begin
+                int32_len_call_count[] += 1
+                x * 4
+            end::Int
+        end
+
+        @test test_vec_memo_int32_len(1) == 4
+        @test int32_len_call_count[] == 1
+        @test test_vec_memo_int32_len(1) == 4
+        @test int32_len_call_count[] == 1
     end
 
     @testset "@memoize concurrency" begin


### PR DESCRIPTION
Both were ports of CUDA.jl's per-thread caches and had several problems:
- values computed during precompilation were serialized into the pkgimage and reused (stale) in later sessions;
- caches were indexed by Threads.threadid(), unsafe under task migration (data races on the keyed Dict, torn reads on small-union slots);
- the LazyInitialized validator path could tear for wide isbits values.

Rework both abstractions:
- LazyInitialized becomes a minimal once-per-process cell (@atomic value + ReentrantLock). The validator and the F type parameter are removed: they were unused by the sole consumer, CUDA.jl, which does its own context-aware revalidation. (Breaking: drops the validator argument and second type parameter.)
- @memoize drops per-thread sharding: the no-key form reuses LazyInitialized, maxlen uses a shared AtomicMemory (lock-free on 1.11+, lock fallback on 1.10), and arbitrary keys use a lock-protected Dict.
- Values computed during precompile are no longer persisted: wiped on serialize via jl_set_precompile_field_replace on 1.12+, and simply not published on 1.10/1.11.

The macro now references its helpers via hygienic GlobalRefs instead of assuming they are in scope at the use site. Hot paths are allocation-free (no-key ~2ns, maxlen ~2.6ns, dict ~12ns). Tested on 1.10, 1.11 and 1.12, including thread-migration stress and a subprocess session-safety check.