### PR TITLE
Redesign @memoize index mode

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GPUToolbox"
 uuid = "096a3bc2-3ced-46d0-87f4-dd12716f4bfc"
-version = "2.0.0"
+version = "3.0.0"
 
 [deps]
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"

--- a/src/memoization.jl
+++ b/src/memoization.jl
@@ -209,7 +209,8 @@ macro memoize(ex...)
                 @static if VERSION >= v"1.11"
                     data = @atomic :acquire cache.data
                     if data !== nothing && 1 <= key <= length(data)
-                        cached_value = $slot_load(data, key)
+                        # bounds already checked above; skip the redundant check
+                        cached_value = @inbounds $slot_load(data, key)
                         if cached_value !== nothing
                             Base.something(cached_value)::$rettyp_esc
                         else

--- a/src/memoization.jl
+++ b/src/memoization.jl
@@ -49,77 +49,60 @@ Base.@propagate_inbounds @inline function memoize_slot_store!(
     return val
 end
 
-function memoize_new_slots(::Type{T}, len) where {T}
-    len = Int(len)
-    data = _SlotArray{T}(undef, len)
-    for i in eachindex(data)
+@inline memoize_grow_len(oldlen::Int, key::Int) = max(key, 2 * oldlen)
+
+function memoize_grow_slots(::Type{T}, old::Union{Nothing,_SlotArray{T}}, newlen) where {T}
+    newlen = Int(newlen)
+    data = _SlotArray{T}(undef, newlen)
+    n = old === nothing ? 0 : length(old)
+    @inbounds for i in 1:n
+        memoize_slot_store!(data, i, memoize_slot_load(old, i))
+    end
+    @inbounds for i in (n + 1):newlen
         memoize_slot_store!(data, i, nothing)
     end
     return data
 end
 
-@noinline function memoize_fixed_data!(m::FixedMemo{T}, len) where {T}
-    data = @atomic :acquire m.data
-    data !== nothing && return data
-    memoize_should_publish() || return nothing
+@noinline function memoize_grow_slow!(constructor, m::FixedMemo{T}, key) where {T}
+    key = Int(key)
+    key >= 1 || throw(BoundsError())
+    memoize_should_publish() || return constructor()::T
 
     @lock m.lock begin
         data = @atomic :acquire m.data
         if data === nothing
-            data = memoize_new_slots(T, len)
+            data = memoize_grow_slots(T, nothing, memoize_grow_len(0, key))
             generating_output() && wipe_on_serialize!(m, :data, nothing)
             @atomic :release m.data = data
-        end
-        return data
-    end
-end
-
-@noinline function memoize_slow!(constructor, m::FixedMemo{T}, key, len) where {T}
-    len = Int(len)
-    @static if VERSION >= v"1.11"
-        data = memoize_fixed_data!(m, len)
-        if data === nothing
-            checkbounds(1:len, key)
-            return constructor()::T
+        elseif key > length(data)
+            oldlen = length(data)
+            newlen = memoize_grow_len(oldlen, key)
+            @static if VERSION >= v"1.11"
+                data = memoize_grow_slots(T, data, newlen)
+                generating_output() && wipe_on_serialize!(m, :data, nothing)
+                @atomic :release m.data = data
+            else
+                generating_output() && wipe_on_serialize!(m, :data, nothing)
+                resize!(data, newlen)
+                @inbounds for i in (oldlen + 1):newlen
+                    memoize_slot_store!(data, i, nothing)
+                end
+            end
         end
 
         cached = memoize_slot_load(data, key)
         cached !== nothing && return Base.something(cached)::T
 
         val = constructor()::T
-        if memoize_should_publish()
-            generating_output() && wipe_on_serialize!(m, :data, nothing)
-            memoize_slot_store!(data, key, Some{T}(val))
-        end
+        generating_output() && wipe_on_serialize!(m, :data, nothing)
+        memoize_slot_store!(data, key, Some{T}(val))
         return val
-    else
-        @lock m.lock begin
-            data = @atomic :acquire m.data
-            if data === nothing
-                if !memoize_should_publish()
-                    checkbounds(1:len, key)
-                    return constructor()::T
-                end
-                data = memoize_new_slots(T, len)
-                generating_output() && wipe_on_serialize!(m, :data, nothing)
-                @atomic :release m.data = data
-            end
-
-            cached = memoize_slot_load(data, key)
-            cached !== nothing && return Base.something(cached)::T
-
-            val = constructor()::T
-            if memoize_should_publish()
-                generating_output() && wipe_on_serialize!(m, :data, nothing)
-                memoize_slot_store!(data, key, Some{T}(val))
-            end
-            return val
-        end
     end
 end
 
 """
-    @memoize [key::T] [maxlen=...] begin
+    @memoize [key=expr::K | index=expr] begin
         # expensive computation
     end::T
 
@@ -127,32 +110,61 @@ Low-level, no-frills memoization macro that stores values in a process-local, ty
 The types of the caches are derived from the syntactical type assertions.
 All return values, including `nothing`, are memoized correctly.
 
-If the `maxlen` option is specified, the `key` is assumed to be an integer, and the
-cache will be a fixed-size array with length `maxlen`. Otherwise, a dictionary is used.
-On Julia 1.11+, fixed-size slots use atomic per-element access. Atomic slot access is
-lock-free for pointer-representable values; other values may use Julia's internal
-per-element atomic fallback.
+With no leading argument, a single value is memoized. Use `key=expr::K` for dictionary
+memoization keyed by values of type `K`. Use `index=expr` for array-backed memoization
+with small, dense, positive integer indices; sparse or large keys should use dictionary
+mode instead. Index mode grows the backing array on demand. On Julia 1.11+, index-mode
+slots use atomic per-element access. Atomic slot access is lock-free for
+pointer-representable values; other values may use Julia's internal per-element atomic
+fallback.
 """
 macro memoize(ex...)
     code = ex[end]
     args = ex[1:end-1]
 
     # decode the code body
-    @assert Meta.isexpr(code, :(::))
+    Meta.isexpr(code, :(::)) ||
+        throw(ArgumentError("@memoize requires the body to end in `end::T`"))
     rettyp = code.args[2]
     code = code.args[1]
 
     # decode the arguments
+    mode = :single
     key = nothing
-    if length(args) >= 1
-        arg = args[1]
-        @assert Meta.isexpr(arg, :(::))
-        key = (val=arg.args[1], typ=arg.args[2])
-    end
-    options = Dict()
-    for arg in args[2:end]
-        @assert Meta.isexpr(arg, :(=))
-        options[arg.args[1]] = arg.args[2]
+    index = nothing
+    for arg in args
+        if !Meta.isexpr(arg, :(=))
+            throw(ArgumentError(
+                "@memoize positional keys are no longer supported; use `key=expr::K` " *
+                "for dictionary mode or `index=expr` for array mode",
+            ))
+        end
+
+        name, val = arg.args
+        if name === :key
+            mode === :single ||
+                throw(ArgumentError("@memoize accepts only one of `key=` or `index=`"))
+            Meta.isexpr(val, :(::)) ||
+                throw(ArgumentError("@memoize `key=` requires a type assertion, e.g. `key=x::Int`"))
+            key = (val=val.args[1], typ=val.args[2])
+            mode = :dict
+        elseif name === :index
+            mode === :single ||
+                throw(ArgumentError("@memoize accepts only one of `key=` or `index=`"))
+            Meta.isexpr(val, :(::)) &&
+                throw(ArgumentError("@memoize `index=` does not take a type assertion; use `index=x`"))
+            index = val
+            mode = :array
+        elseif name === :maxlen
+            throw(ArgumentError(
+                "@memoize `maxlen=` is no longer supported; use `index=expr` for " *
+                "dense integer indices or `key=expr::K` for dictionary mode",
+            ))
+        else
+            throw(ArgumentError(
+                "@memoize unknown option `$name`; expected `key=expr::K` or `index=expr`",
+            ))
+        end
     end
 
     @gensym global_cache
@@ -161,9 +173,7 @@ macro memoize(ex...)
     fixed_ty = GlobalRef(mod, :FixedMemo)
     dict_ty = GlobalRef(mod, :DictMemo)
     slot_load = GlobalRef(mod, :memoize_slot_load)
-    slot_store = GlobalRef(mod, :memoize_slot_store!)
-    new_slots = GlobalRef(mod, :memoize_new_slots)
-    fixed_slow = GlobalRef(mod, :memoize_slow!)
+    grow_slow = GlobalRef(mod, :memoize_grow_slow!)
     should_publish = GlobalRef(mod, :memoize_should_publish)
     generating = GlobalRef(mod, :generating_output)
     wipe = GlobalRef(mod, :wipe_on_serialize!)
@@ -171,7 +181,7 @@ macro memoize(ex...)
     rettyp_esc = esc(rettyp)
     code_esc = esc(code)
 
-    if key === nothing
+    if mode === :single
         @eval __module__ begin
             const $global_cache = $lazy_ty{$rettyp}()
         end
@@ -188,73 +198,38 @@ macro memoize(ex...)
                 end
             end
         end
-    elseif haskey(options, :maxlen)
+    elseif mode === :array
         @eval __module__ begin
             const $global_cache = $fixed_ty{$rettyp}()
         end
 
-        key_val_esc = esc(key.val)
-        maxlen_esc = esc(options[:maxlen])
+        index_esc = esc(index)
         ex = quote
-            let cache = $(esc(global_cache)), key = $key_val_esc
+            let cache = $(esc(global_cache)), key = Int($index_esc)
                 @static if VERSION >= v"1.11"
                     data = @atomic :acquire cache.data
-                    if data !== nothing
+                    if data !== nothing && 1 <= key <= length(data)
                         cached_value = $slot_load(data, key)
                         if cached_value !== nothing
                             Base.something(cached_value)::$rettyp_esc
                         else
-                            $fixed_slow(cache, key, $maxlen_esc) do
+                            $grow_slow(cache, key) do
                                 $code_esc::$rettyp_esc
                             end
                         end
                     else
-                        $fixed_slow(cache, key, $maxlen_esc) do
+                        $grow_slow(cache, key) do
                             $code_esc::$rettyp_esc
                         end
                     end
                 else
-                    @lock cache.lock begin
-                        len = $maxlen_esc
-                        publish = $should_publish()
-                        data = @atomic :acquire cache.data
-                        if data === nothing
-                            if !publish
-                                checkbounds(1:len, key)
-                                $code_esc::$rettyp_esc
-                            else
-                                data = $new_slots($rettyp_esc, len)
-                                $generating() && $wipe(cache, :data, nothing)
-                                @atomic :release cache.data = data
-
-                                cached_value = $slot_load(data, key)
-                                if cached_value !== nothing
-                                    Base.something(cached_value)::$rettyp_esc
-                                else
-                                    new_value = $code_esc::$rettyp_esc
-                                    $generating() && $wipe(cache, :data, nothing)
-                                    $slot_store(data, key, Base.Some{$rettyp_esc}(new_value))
-                                    new_value
-                                end
-                            end
-                        else
-                            cached_value = $slot_load(data, key)
-                            if cached_value !== nothing
-                                Base.something(cached_value)::$rettyp_esc
-                            else
-                                new_value = $code_esc::$rettyp_esc
-                                if publish
-                                    $generating() && $wipe(cache, :data, nothing)
-                                    $slot_store(data, key, Base.Some{$rettyp_esc}(new_value))
-                                end
-                                new_value
-                            end
-                        end
+                    $grow_slow(cache, key) do
+                        $code_esc::$rettyp_esc
                     end
                 end
             end
         end
-    else
+    elseif mode === :dict
         @eval __module__ begin
             const $global_cache = $dict_ty{$(key.typ),$rettyp}()
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,7 +187,7 @@ using IOCapture
         # Test memoization with key (dictionary)
         dict_call_count = Ref(0)
         function test_dict_memo(x)
-            @memoize x::Int begin
+            @memoize key=x::Int begin
                 dict_call_count[] += 1
                 x * 2
             end::Int
@@ -202,7 +202,7 @@ using IOCapture
 
         dict_nothing_call_count = Ref(0)
         function test_dict_nothing_memo(x)
-            @memoize x::Int begin
+            @memoize key=x::Int begin
                 dict_nothing_call_count[] += 1
                 nothing
             end::Union{Nothing,Int}
@@ -215,50 +215,81 @@ using IOCapture
         @test test_dict_nothing_memo(3) === nothing
         @test dict_nothing_call_count[] == 2
 
-        # Test memoization with maxlen (vector)
-        vec_call_count = Ref(0)
-        function test_vec_memo(x)
-            @memoize x::Int maxlen=10 begin
-                vec_call_count[] += 1
+        # Test memoization with index (auto-growing array)
+        index_call_count = Ref(0)
+        function test_index_memo(x)
+            @memoize index=x begin
+                index_call_count[] += 1
                 x * 3
             end::Int
         end
 
-        @test test_vec_memo(1) == 3
-        @test vec_call_count[] == 1
-        @test test_vec_memo(1) == 3
-        @test vec_call_count[] == 1  # Should not increment
-        @test test_vec_memo(2) == 6
-        @test vec_call_count[] == 2  # Should increment for new index
+        @test test_index_memo(1) == 3
+        @test index_call_count[] == 1
+        @test test_index_memo(1) == 3
+        @test index_call_count[] == 1  # Should not increment
+        @test test_index_memo(2) == 6
+        @test index_call_count[] == 2  # Should increment for new index
 
-        vec_nothing_call_count = Ref(0)
-        function test_vec_nothing_memo(x)
-            @memoize x::Int maxlen=10 begin
-                vec_nothing_call_count[] += 1
+        index_nothing_call_count = Ref(0)
+        function test_index_nothing_memo(x)
+            @memoize index=x begin
+                index_nothing_call_count[] += 1
                 nothing
             end::Union{Nothing,Int}
         end
 
-        @test test_vec_nothing_memo(1) === nothing
-        @test vec_nothing_call_count[] == 1
-        @test test_vec_nothing_memo(1) === nothing
-        @test vec_nothing_call_count[] == 1
-        @test test_vec_nothing_memo(2) === nothing
-        @test vec_nothing_call_count[] == 2
+        @test test_index_nothing_memo(1) === nothing
+        @test index_nothing_call_count[] == 1
+        @test test_index_nothing_memo(1) === nothing
+        @test index_nothing_call_count[] == 1
+        @test test_index_nothing_memo(2) === nothing
+        @test index_nothing_call_count[] == 2
 
-        # `maxlen` may come from APIs that return smaller integer types.
-        int32_len_call_count = Ref(0)
-        function test_vec_memo_int32_len(x)
-            @memoize x::Int maxlen=Int32(10) begin
-                int32_len_call_count[] += 1
-                x * 4
+        # `index` may come from APIs that return smaller integer types.
+        int32_index_call_count = Ref(0)
+        function test_index_memo_int32_index(x)
+            @memoize index=x begin
+                int32_index_call_count[] += 1
+                Int(x) * 4
             end::Int
         end
 
-        @test test_vec_memo_int32_len(1) == 4
-        @test int32_len_call_count[] == 1
-        @test test_vec_memo_int32_len(1) == 4
-        @test int32_len_call_count[] == 1
+        @test test_index_memo_int32_index(Int32(1)) == 4
+        @test int32_index_call_count[] == 1
+        @test test_index_memo_int32_index(Int32(1)) == 4
+        @test int32_index_call_count[] == 1
+
+        grow_counts = zeros(Int, 12)
+        function test_index_grow(x)
+            @memoize index=x begin
+                grow_counts[x] += 1
+                x + 100
+            end::Int
+        end
+
+        @test [test_index_grow(i) for i in 1:12] == collect(101:112)
+        @test [test_index_grow(i) for i in 1:12] == collect(101:112)
+        @test all(==(1), grow_counts)
+
+        bad_index_call_count = Ref(0)
+        function test_bad_index_memo(x)
+            @memoize index=x begin
+                bad_index_call_count[] += 1
+                x
+            end::Int
+        end
+
+        @test_throws BoundsError test_bad_index_memo(0)
+        @test_throws BoundsError test_bad_index_memo(-1)
+        @test bad_index_call_count[] == 0
+
+        @test_throws ArgumentError macroexpand(
+            @__MODULE__, :(@memoize x::Int begin x end::Int)
+        )
+        @test_throws ArgumentError macroexpand(
+            @__MODULE__, :(@memoize maxlen=2 begin 1 end::Int)
+        )
     end
 
     @testset "@memoize concurrency" begin
@@ -277,7 +308,7 @@ using IOCapture
 
         dict_count = Threads.Atomic{Int}(0)
         function memo_dict_stress(x)
-            @memoize x::Int begin
+            @memoize key=x::Int begin
                 Threads.atomic_add!(dict_count, 1)
                 yield()
                 x * 10
@@ -289,23 +320,38 @@ using IOCapture
         @test fetch.(tasks) == keys .* 10
         @test dict_count[] == 16
 
-        fixed_count = Threads.Atomic{Int}(0)
-        function memo_fixed_stress(x)
-            @memoize x::Int maxlen=16 begin
-                Threads.atomic_add!(fixed_count, 1)
+        index_count = Threads.Atomic{Int}(0)
+        function memo_index_stress(x)
+            @memoize index=x begin
+                Threads.atomic_add!(index_count, 1)
                 yield()
                 x * 20
             end::Int
         end
 
-        tasks = [Threads.@spawn memo_fixed_stress(key) for key in keys]
+        tasks = [Threads.@spawn memo_index_stress(key) for key in keys]
         @test fetch.(tasks) == keys .* 20
-        @test 16 <= fixed_count[] <= length(keys)
+        @test index_count[] == 16
 
-        fixed_count_after_warmup = fixed_count[]
-        tasks = [Threads.@spawn memo_fixed_stress(key) for key in keys]
+        index_count_after_warmup = index_count[]
+        tasks = [Threads.@spawn memo_index_stress(key) for key in keys]
         @test fetch.(tasks) == keys .* 20
-        @test fixed_count[] == fixed_count_after_warmup
+        @test index_count[] == index_count_after_warmup
+
+        grow_race_count = Threads.Atomic{Int}(0)
+        function memo_index_grow_race(x)
+            @memoize index=x begin
+                Threads.atomic_add!(grow_race_count, 1)
+                yield()
+                x * 30
+            end::Int
+        end
+
+        @test memo_index_grow_race(1) == 30
+        @test grow_race_count[] == 1
+        tasks = [Threads.@spawn memo_index_grow_race(64) for _ in 1:128]
+        @test all(==(64 * 30), fetch.(tasks))
+        @test grow_race_count[] == 2
     end
 
     @testset "Session-safe caches" begin
@@ -339,23 +385,26 @@ using IOCapture
                 end::Int
             end
 
-            function memo_fixed_pid(key)
-                @memoize key::Int maxlen=2 begin
+            function memo_index_pid(key)
+                @memoize index=key begin
                     Int(getpid())
                 end::Int
             end
 
             function memo_dict_pid(key)
-                @memoize key::Int begin
+                @memoize key=key::Int begin
                     Int(getpid())
                 end::Int
             end
 
+            precompile_values() =
+                (lazy_pid(), memo_no_key_pid(), memo_index_pid(1), memo_dict_pid(1))
+
             runtime_values() =
-                (lazy_pid(), memo_no_key_pid(), memo_fixed_pid(1), memo_dict_pid(1))
+                (lazy_pid(), memo_no_key_pid(), memo_index_pid(1), memo_index_pid(4), memo_dict_pid(1))
 
             if ccall(:jl_generating_output, Cint, ()) != 0
-                PRECOMPILE[] = runtime_values()
+                PRECOMPILE[] = precompile_values()
             end
 
             end
@@ -381,8 +430,8 @@ using IOCapture
             line = only(filter(startswith("RESULT "), split(out, '\n')))
             nums = parse.(Int, split(chop(line; head=7, tail=0), ","))
             precompile_vals = nums[1:4]
-            runtime_vals = nums[5:8]
-            runtime_pid = nums[9]
+            runtime_vals = nums[5:9]
+            runtime_pid = nums[10]
 
             @test all(!=(0), precompile_vals)
             @test all(==(runtime_pid), runtime_vals)


### PR DESCRIPTION
The switch is more clear now: `@memoize` without argumen is single-value mode, passing `index=` triggers array mode, passing `key=` triggers Dict mode. Breaking change.